### PR TITLE
Create .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.{js,json,ts}]
+indent_size = 2
+
+[*.{html}]
+indent_size = 4
+
+[*.{css}]
+indent_size = 4
+
+[*.{yml}]
+indent_size = 2
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false


### PR DESCRIPTION
The `*.js` files would have 2 spaces, when `*.html` and `*.css` files would have 4 spaces